### PR TITLE
feat(file visibility): hide hidden files

### DIFF
--- a/src/FileTreeExplorer.tsx
+++ b/src/FileTreeExplorer.tsx
@@ -74,6 +74,11 @@ export const FileTreeExplorer = () => {
     setTreeData(newTreeData);
   };
 
+  const isHiddenFile = (node) => {
+    if (!node.text) return true;
+    if (node.data.hidden && !node.droppable) return true;
+  };
+
   const entryFile = getEntryFile(sandpack.files);
 
   return (
@@ -124,7 +129,7 @@ export const FileTreeExplorer = () => {
             // onChangeOpen={(e) => setOpenDirs(e as string[])}
             // initialOpen={openDirs} //treeData.map(({ id }) => id)}
             render={(node, { depth, isOpen }) =>
-              !node.text ? (
+              isHiddenFile(node) ? (
                 <></>
               ) : (
                 <div

--- a/src/utils/deepMerge.tsx
+++ b/src/utils/deepMerge.tsx
@@ -14,7 +14,7 @@ export function deepMerge(
     if (!result[prop]) {
       result[prop] = {};
     }
-    if (typeof obj2[prop] === 'object') {
+    if (typeof obj2[prop] === 'object' && obj2[prop] !== null) {
       // If the objects being merged are empty, return null instead of calling deepMerge()
       if (
         Object.keys(obj1?.[prop] || {})?.length === 0 &&
@@ -42,7 +42,7 @@ export function deepMerge(
         }
       }
     } else {
-      result[prop] = files[`${path}`]?.code;
+      result[prop] = files[`${path}`]?.hidden;
     }
   }
 

--- a/src/utils/toHierarchicalArray.tsx
+++ b/src/utils/toHierarchicalArray.tsx
@@ -26,6 +26,7 @@ export const toHierarchicalArray = (
         text: text,
         data: {
           path: `/${builtPath}`,
+          hidden: obj[key],
         },
         droppable: false,
       };

--- a/stories/SandpackFileExplorer.stories.mdx
+++ b/stories/SandpackFileExplorer.stories.mdx
@@ -43,7 +43,11 @@ Use it in the same way and enjoy all the extra functionality!
   }}
 >
   <Story name="Complete">
-    <SandpackProvider theme={nightOwl} template="react-ts">
+    <SandpackProvider
+      theme={nightOwl}
+      template="react-ts"
+      files={{ '/hidden.tsx': { code: '// hidden.tsx', hidden: true } }}
+    >
       <SandpackStack>
         <div
           style={{


### PR DESCRIPTION
Hidden files were not being hidden in the file tree.

It seemed that the property "result[prop]" was not being used other than it needing to not be an object, so I used it as a hidden flag. 

Maybe it is a bit hacky, but it works.

