### PR TITLE
Fixes of issue #7 by adding the types field to the exports section in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,12 +58,13 @@
     ]
   },
   "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
-    }
-  },
+ "exports": {
+  ".": {
+    "require": "./dist/index.js",
+    "import": "./dist/index.mjs",
+    "types": "./dist/index.d.ts"
+  }
+},
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Add "types" Field to package.json "exports" for TypeScript Support
Description
This PR fixes a TypeScript error (TS7016) where the sandpack-file-explorer module is treated as having an any type due to missing type definitions in the package.json "exports" field. The error occurs in TypeScript projects using moduleResolution: "Node16" or "NodeNext", as TypeScript cannot resolve the index.d.ts file.
The change adds a "types" field to the "exports" section in package.json, pointing to the existing index.d.ts file, enabling proper type resolution.
Changes Made

Updated package.json to include "types": "./dist/index.d.ts" in the "exports" section:"exports": {
  ".": {
    "require": "./dist/index.js",
    "import": "./dist/index.mjs",
    "types": "./dist/index.d.ts"
  }
}



Related Issue

Fixes #[Insert Issue Number Here] (to be updated after creating the issue).

Testing

Tested locally in a TypeScript project (scholarhattcompiler) with moduleResolution: "NodeNext".
Confirmed that the TS7016 error is resolved, and TypeScript correctly recognizes the module’s types from index.d.ts.
Verified that the index.d.ts file exists at the specified path (./dist/index.d.ts).

Additional Notes

This change maintains backward compatibility with existing CommonJS and ES Module imports.
No additional dependencies or code changes were required.
Suggest reviewing the index.d.ts file to ensure it covers all exported APIs correctly.
